### PR TITLE
chore: remove error assert status

### DIFF
--- a/modules/assert_logic.py
+++ b/modules/assert_logic.py
@@ -9,7 +9,6 @@ class AssertStatus(Enum):
 
     PASS = auto()
     FAIL = auto()
-    ERROR = auto()  # Ошибка в данных проверки (например, неверный regexp)
     WARN = auto()  # Неподдерживаемый тип проверки
 
 


### PR DESCRIPTION
## Summary
- drop unused `ERROR` from `AssertStatus`

## Testing
- `flake8 modules/assert_logic.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb4a7662a4832e8c27f1fa8181d392