### PR TITLE
Return CompletedProcess from run_bash executor

### DIFF
--- a/modules/bash_executor.py
+++ b/modules/bash_executor.py
@@ -1,69 +1,76 @@
 # modules/bash_executor.py
-import subprocess
-import shlex
+"""Utility functions for running shell commands with error handling."""
 
-# 1. Вводим пользовательское исключение для явной обработки ошибок.
+from __future__ import annotations
+
+import subprocess
+
+
 class CommandError(Exception):
     """Исключение, возникающее при ошибке выполнения внешней команды."""
-    def __init__(self, message, stderr="", returncode=None):
+
+    def __init__(self, message: str, stderr: str = "", returncode: int | None = None):
         super().__init__(message)
         self.stderr = stderr
         self.returncode = returncode
 
-    def __str__(self):
+    def __str__(self) -> str:  # pragma: no cover - simple formatting
         if self.returncode is not None:
             return f"Command failed with exit code {self.returncode}: {self.stderr}"
         return super().__str__()
 
 
-def run_bash(command: str, timeout: int = 10) -> str:
-    """
-    Выполняет команду в оболочке bash с контролем ошибок и таймаутом.
+def run_bash(
+    command: str,
+    timeout: int = 10,
+    rc_ok: tuple[int, ...] = (0, 1),
+) -> subprocess.CompletedProcess:
+    """Run *command* in a shell and return the completed process.
 
     Args:
         command: Строка с командой для выполнения.
         timeout: Максимальное время выполнения команды в секундах.
+        rc_ok: Коды возврата, которые считаются успешными.
 
     Returns:
-        Стандартный вывод (stdout) команды в виде строки.
+        Объект :class:`subprocess.CompletedProcess`.
 
     Raises:
-        CommandError: Если команда завершается с ненулевым кодом возврата,
-                      истекает таймаут или происходит другая ошибка выполнения.
+        CommandError: Если код возврата не входит в ``rc_ok`` или возникла
+            другая ошибка выполнения.
     """
+
     # ВАЖНО: Использование shell=True представляет риск безопасности, если команда
     # может быть подконтрольна злоумышленнику. В данном случае команды поступают
     # из доверенных YAML-профилей, но этот риск необходимо осознавать.
     try:
-        # 2. Используем subprocess.run с таймаутом и проверкой кода возврата.
         result = subprocess.run(
             command,
             shell=True,
             text=True,
-            capture_output=True, # Более современный аналог stdout/stderr=PIPE
+            capture_output=True,
             timeout=timeout,
-            check=False  # Мы будем проверять код возврата вручную
+            check=False,
         )
 
-        # 3. Проверяем код возврата. Если не 0, выбрасываем наше исключение с stderr.
-        if result.returncode != 0:
+        if result.returncode not in rc_ok:
             raise CommandError(
                 message=f"Command '{command}' failed.",
-                stderr=result.stderr.strip(),
-                returncode=result.returncode
+                stderr=(result.stderr or "").strip(),
+                returncode=result.returncode,
             )
 
-        # 4. Если все успешно, возвращаем stdout.
-        return result.stdout.strip()
+        return result
 
-    except subprocess.TimeoutExpired as e:
+    except subprocess.TimeoutExpired as e:  # pragma: no cover - rare
         raise CommandError(
             f"Command '{command}' timed out after {timeout} seconds.",
-            stderr=e.stderr or ""
+            stderr=e.stderr or "",
         ) from e
-    except FileNotFoundError as e:
-        # Эта ошибка возникает, если сама оболочка (/bin/sh) не найдена
+    except FileNotFoundError as e:  # pragma: no cover - environment issue
         raise CommandError(f"Shell not found: {e}") from e
-    except Exception as e:
-        # Ловим любые другие непредвиденные ошибки subprocess
-        raise CommandError(f"An unexpected error occurred while running command: {e}") from e
+    except Exception as e:  # pragma: no cover - defensive
+        raise CommandError(
+            f"An unexpected error occurred while running command: {e}"
+        ) from e
+


### PR DESCRIPTION
## Summary
- change `run_bash` to return `subprocess.CompletedProcess` and accept allowed return codes
- raise `CommandError` when return code not in allowed set and remove unused `shlex` import

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb4a73f7ac832e98355e14f550bf4a