### PR TITLE
feat: extend CLI profile schema assert types

### DIFF
--- a/modules/cli.py
+++ b/modules/cli.py
@@ -35,7 +35,17 @@ _PROFILE_SCHEMA = {
                     "module": {"type": "string"},
                     "command": {"type": "string"},
                     "expect": {"type": "string"},
-                    "assert_type": {"type": "string", "enum": ["exact", "contains", "regexp"]},
+                    # Допустимые типы сравнения: exact | contains | not_contains | regexp | exit_code
+                    "assert_type": {
+                        "type": "string",
+                        "enum": [
+                            "exact",
+                            "contains",
+                            "not_contains",
+                            "regexp",
+                            "exit_code",
+                        ],
+                    },
                     "severity": {"type": "string", "enum": ["low", "medium", "high"]},
                     # Важно: теги — словарь {строка: строка}. Если у тебя массивы, конверти в строку заранее.
                     "tags": {


### PR DESCRIPTION
## Summary
- allow `not_contains` and `exit_code` in CLI profile schema assert types
- document supported assert types in profile schema

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb4cfd8d08832e88f76f13a8ff21fe