### PR TITLE
Normalize profile before validation and add extra checks

### DIFF
--- a/seclib/validator.py
+++ b/seclib/validator.py
@@ -108,11 +108,14 @@ def validate_profile(profile: Dict[str, Any]) -> Tuple[bool, List[str]]:
     Валидирует YAML-профиль по JSON-схеме.
     Возвращает (is_valid, errors[]).
     """
+    profile = normalize_profile(profile)
     validator = Draft7Validator(PROFILE_SCHEMA)
     errors: List[str] = []
     for err in sorted(validator.iter_errors(profile), key=lambda e: e.path):
         loc = " -> ".join([str(p) for p in err.path]) or "<root>"
         errors.append(f"{loc}: {err.message}")
+    errors.extend(_check_unique_ids(profile.get("checks", [])))
+    errors.extend(_precompile_regexps(profile.get("checks", [])))
     return (len(errors) == 0, errors)
 
 def severity_rank(sev: str) -> int:


### PR DESCRIPTION
## Summary
- Normalize profiles before validation
- Check duplicate IDs and invalid regex patterns when validating profiles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb4d002754832eaf35f648631c9c67