### PR TITLE
Fix schema validation and CLI profile flag handling

### DIFF
--- a/modules/cli.py
+++ b/modules/cli.py
@@ -18,6 +18,7 @@ except Exception:
 
 
 _PROFILE_SCHEMA = STRICT_PROFILE_SCHEMA
+DEFAULT_PROFILE_PATH = "profiles/common/baseline.yml"
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -152,9 +153,14 @@ def validate_profile(profile: Dict[str, Any]) -> Tuple[bool, List[str]]:
 # ──────────────────────────────────────────────────────────────────────────────
 # Парсинг аргументов
 # ──────────────────────────────────────────────────────────────────────────────
-def _parent_parser() -> argparse.ArgumentParser:
+def _parent_parser(default_profile: str) -> argparse.ArgumentParser:
     """Родительский парсер с общими для подкоманд аргументами (если нужно)."""
     parent = argparse.ArgumentParser(add_help=False)
+    parent.add_argument(
+        "--profile",
+        default=argparse.SUPPRESS,
+        help=f"Путь к YAML-профилю (по умолчанию: {default_profile})",
+    )
     return parent
 
 
@@ -165,7 +171,8 @@ def parse_args() -> argparse.Namespace:
       secaudit --profile profiles/alt.yml list-modules
       secaudit list-modules --profile profiles/alt.yml
     """
-    parent = _parent_parser()
+    default_profile = DEFAULT_PROFILE_PATH
+    parent = _parent_parser(default_profile)
 
     parser = argparse.ArgumentParser(
         prog="secaudit",
@@ -175,8 +182,8 @@ def parse_args() -> argparse.Namespace:
     # Глобальный флаг профиля — можно ставить до/после команды
     parser.add_argument(
         "--profile",
-        default="profiles/common/baseline.yml",
-        help="Путь к YAML-профилю (по умолчанию: profiles/common/baseline.yml)",
+        default=default_profile,
+        help=f"Путь к YAML-профилю (по умолчанию: {default_profile})",
     )
 
     subs = parser.add_subparsers(dest="command", required=True, help="Доступные команды")
@@ -225,7 +232,10 @@ def parse_args() -> argparse.Namespace:
         help="Каталог для сохранения выводов команд (улики)."
     )
 
-    return parser.parse_args()
+    args = parser.parse_args()
+    if not hasattr(args, "profile"):
+        args.profile = default_profile
+    return args
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/seclib/validator.py
+++ b/seclib/validator.py
@@ -17,7 +17,7 @@ PROFILE_SCHEMA: Dict[str, Any] = {
     "type": "object",
     "required": ["schema_version", "profile_name", "description", "checks"],
     "properties": {
-        "schema_version": {"type": "string", "pattern": r"^1\\.\d+$"},
+        "schema_version": {"type": "string", "pattern": r"^1\.\d+$"},
         "profile_name": {"type": "string", "minLength": 1},
         "description": {"type": "string"},
         "checks": {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,39 @@
+import pytest
+
+from modules import cli
+
+
+@pytest.mark.parametrize(
+    "argv, expected_profile",
+    [
+        (["secaudit", "audit", "--profile", "profiles/alt.yml"], "profiles/alt.yml"),
+        (["secaudit", "--profile", "profiles/alt.yml", "audit"], "profiles/alt.yml"),
+    ],
+)
+def test_parse_args_allows_profile_any_position(monkeypatch, argv, expected_profile):
+    monkeypatch.setattr(cli.sys, "argv", argv)
+
+    args = cli.parse_args()
+
+    assert args.command == "audit"
+    assert args.profile == expected_profile
+
+
+def test_parse_args_additional_subcommand_arguments_preserved(monkeypatch):
+    argv = [
+        "secaudit",
+        "audit",
+        "--profile",
+        "profiles/alt.yml",
+        "--fail-on-undef",
+        "--fail-level",
+        "medium",
+    ]
+    monkeypatch.setattr(cli.sys, "argv", argv)
+
+    args = cli.parse_args()
+
+    assert args.command == "audit"
+    assert args.profile == "profiles/alt.yml"
+    assert args.fail_on_undef is True
+    assert args.fail_level == "medium"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,45 @@
+import pytest
+
+from seclib.validator import validate_profile
+
+
+@pytest.fixture
+def minimal_check():
+    return {
+        "id": "dummy_check",
+        "name": "Dummy",
+        "module": "core",
+        "command": "echo ok",
+        "expect": "ok",
+        "assert_type": "exact",
+        "severity": "low",
+        "tags": {},
+    }
+
+
+def test_validate_profile_accepts_1_x_schema_version(minimal_check):
+    profile = {
+        "schema_version": "1.1",
+        "profile_name": "Test",
+        "description": "Test profile",
+        "checks": [minimal_check],
+    }
+
+    is_valid, errors = validate_profile(profile)
+
+    assert is_valid, f"Profile unexpectedly invalid: {errors}"
+    assert errors == []
+
+
+def test_validate_profile_rejects_invalid_schema_version(minimal_check):
+    profile = {
+        "schema_version": "1.a",
+        "profile_name": "Test",
+        "description": "Test profile",
+        "checks": [minimal_check],
+    }
+
+    is_valid, errors = validate_profile(profile)
+
+    assert not is_valid
+    assert any("schema_version" in err for err in errors)


### PR DESCRIPTION
## Summary
- fix the profile schema regex so 1.x versions validate correctly
- allow the --profile flag to be placed before or after subcommands
- add regression tests for the validator and CLI argument parsing

## Testing
- pytest
- python -m secaudit validate --profile profiles/common/baseline.yml

