### PR TITLE
Support jsonpath expect mappings and profile meta

### DIFF
--- a/profiles/alt.yml
+++ b/profiles/alt.yml
@@ -2,6 +2,11 @@ schema_version: "1.1"
 profile_name: "Alt Linux SP — расширенный профиль (с астра-спецификой)"
 description: "Расширенный аудит безопасности для Alt Linux (СП/Server) с жёсткими SSH, PAM, journald, sysctl и файловыми политиками"
 
+meta:
+  fstec: "https://fstec.ru/normativnye-dokumenty/prikazy/239"
+  cis: "https://www.cisecurity.org/benchmark/linux/"
+  stig: "https://public.cyber.mil/stigs/downloads/"
+
 checks:
   # ─────────────── SSH: базовая политика доступа ───────────────
   # ИЗМЕНЕНО: Все проверки SSH заменены на 'sshd -T' для получения точной активной конфигурации.

--- a/profiles/astra.yml
+++ b/profiles/astra.yml
@@ -2,6 +2,11 @@ schema_version: "1.1"
 profile_name: "Astra Linux SE — усиленный профиль"
 description: "Жёсткий аудит безопасности для Astra Linux Special Edition (Debian-based). Совместим с SecAudit++."
 
+meta:
+  fstec: "https://fstec.ru/normativnye-dokumenty/prikazy/239"
+  cis: "https://www.cisecurity.org/benchmark/debian_linux/"
+  stig: "https://public.cyber.mil/stigs/downloads/"
+
 checks:
   # ───────────────────────────── SSH: базовая политика доступа ─────────────────────────────
   - id: check_ssh_root_login

--- a/profiles/centos.yml
+++ b/profiles/centos.yml
@@ -2,6 +2,11 @@ schema_version: "1.1"
 profile_name: "CentOS/RHEL — усиленный профиль"
 description: "Жёсткий аудит безопасности для CentOS/RHEL-подобных систем. Совместим с SecAudit++."
 
+meta:
+  fstec: "https://fstec.ru/normativnye-dokumenty/prikazy/239"
+  cis: "https://www.cisecurity.org/benchmark/red_hat_enterprise_linux/"
+  stig: "https://public.cyber.mil/stigs/downloads/"
+
 checks:
   # ───────────────────────────── SSH: базовая политика доступа ─────────────────────────────
   # ИЗМЕНЕНО: Все проверки SSH заменены на 'sshd -T' для анализа активной, а не файловой конфигурации.

--- a/profiles/common/baseline.yml
+++ b/profiles/common/baseline.yml
@@ -2,6 +2,11 @@ schema_version: "1.1"
 profile_name: "ФСТЭК. Базовые проверки"
 description: "Базовый аудит параметров безопасности Linux-систем"
 
+meta:
+  fstec: "https://fstec.ru/normativnye-dokumenty/prikazy/239"
+  cis: "https://www.cisecurity.org/cis-benchmarks/"
+  stig: "https://public.cyber.mil/stigs/downloads/"
+
 checks:
   - id: check_ssh_root_login
     name: "Запрещен ли root-вход по SSH"

--- a/profiles/debian.yml
+++ b/profiles/debian.yml
@@ -2,6 +2,11 @@ schema_version: "1.1"
 profile_name: "Debian/Ubuntu — усиленный профиль"
 description: "Жёсткий аудит безопасности для Debian/Ubuntu. Совместим с SecAudit++."
 
+meta:
+  fstec: "https://fstec.ru/normativnye-dokumenty/prikazy/239"
+  cis: "https://www.cisecurity.org/benchmark/debian_linux/"
+  stig: "https://public.cyber.mil/stigs/downloads/"
+
 checks:
   # ───────────────────────────── SSH: базовая политика доступа ─────────────────────────────
   - id: check_ssh_root_login

--- a/seclib/validator.py
+++ b/seclib/validator.py
@@ -20,6 +20,10 @@ PROFILE_SCHEMA: Dict[str, Any] = {
         "schema_version": {"type": "string", "pattern": r"^1\.\d+$"},
         "profile_name": {"type": "string", "minLength": 1},
         "description": {"type": "string"},
+        "meta": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+        },
         "checks": {
             "type": "array",
             "minItems": 1,
@@ -40,7 +44,7 @@ PROFILE_SCHEMA: Dict[str, Any] = {
                     "name": {"type": "string", "minLength": 1},
                     "module": {"type": "string", "minLength": 1},
                     "command": {"type": "string", "minLength": 1},
-                    "expect": {"type": ["string", "number"]},
+                    "expect": {},
                     "assert_type": {
                         "type": "string",
                         "enum": [
@@ -75,6 +79,37 @@ PROFILE_SCHEMA: Dict[str, Any] = {
                         "maxItems": 8,
                     },
                 },
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": {
+                                "assert_type": {"const": "jsonpath"}
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "expect": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                        },
+                                        "value": {},
+                                        "contains": {},
+                                    },
+                                    "required": ["path"],
+                                    "additionalProperties": False,
+                                }
+                            }
+                        },
+                        "else": {
+                            "properties": {
+                                "expect": {"type": ["string", "number"]}
+                            }
+                        },
+                    }
+                ],
                 "additionalProperties": False,
             },
         },

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -60,7 +60,41 @@ def test_validate_profile_accepts_numeric_expect(minimal_check):
     assert is_valid, f"Profile unexpectedly invalid: {errors}"
 
 
-def test_validate_profile_rejects_non_string_number_expect(minimal_check):
+def test_validate_profile_accepts_jsonpath_expect_object(minimal_check):
+    check = minimal_check.copy()
+    check.update(
+        {
+            "assert_type": "jsonpath",
+            "expect": {"path": "$.status", "value": "ok"},
+        }
+    )
+    profile = {
+        "schema_version": "1.1",
+        "profile_name": "Test",
+        "description": "Test profile",
+        "checks": [check],
+    }
+
+    is_valid, errors = validate_profile(profile)
+
+    assert is_valid, f"Profile unexpectedly invalid: {errors}"
+
+
+def test_validate_profile_accepts_meta(minimal_check):
+    profile = {
+        "schema_version": "1.1",
+        "profile_name": "Test",
+        "description": "Test profile",
+        "meta": {"fstec": "https://fstec.ru/documents"},
+        "checks": [minimal_check],
+    }
+
+    is_valid, errors = validate_profile(profile)
+
+    assert is_valid, f"Profile unexpectedly invalid: {errors}"
+
+
+def test_validate_profile_rejects_object_expect_for_non_jsonpath(minimal_check):
     check = minimal_check.copy()
     check["expect"] = {"unsupported": True}
     profile = {


### PR DESCRIPTION
## Summary
- allow profiles to declare optional meta information with string values and validate jsonpath checks expecting mapping-based assertions
- add tests covering jsonpath expect dictionaries and meta support, plus enrich existing profiles with normative meta references

## Testing
- python3 main.py validate --profile /tmp/jsonpath_profile.yml
- pytest tests/test_validator.py

------
https://chatgpt.com/codex/tasks/task_e_68dfc05b0edc8325891b74df60f55486