### PR TITLE
Add specialized security profiles for Russian-certified platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,40 @@
 > SecAudit-core
 
-**SecAudit-core** —  CLI-инструмент для аудита безопасности Linux-систем по профилям ФСТЭК, СТЭК, NIST и ISO.  
+**SecAudit-core** —  CLI-инструмент для аудита безопасности Linux-систем по профилям ФСТЭК, СТЭК, NIST и ISO.
 Ориентирован на автоматизацию, масштабируемость и гибкость (через YAML).
 
 - Поддержка YAML-профилей
 - Аудит SSH, PAM, SUDO, root-настроек
 - JSON-отчёт с PASS/FAIL
 - Расширяемая архитектура
+
+## Специализированные профили 2024
+
+В репозитории появились дополнительные профили с аннотациями на разделы ФСТЭК/КСЗ и отраслевых руководств:
+
+| Файл профиля | Назначение | Рекомендованный класс ФСТЭК |
+|--------------|------------|-----------------------------|
+| `profiles/base-linux.yml` | Базовый baseline для типовых GNU/Linux (PAM, аудит, фаервол) | К4–К3 |
+| `profiles/astra-1.7-ksz.yml` | Astra Linux 1.7 c модулями КСЗ и режимом Киоск-2 | К1–К2 |
+| `profiles/alt-8sp.yml` | ALT 8 СП с контролем iptables, ГОСТ-криптографии и dm-secdel | К2 |
+| `profiles/redos-7.3-8.yml` | РЕД ОС 7.3/8: лимиты, монтирование, сетевой экран | К3 |
+| `profiles/snlsp.yml` | Комплекс SN LSP: службы безопасности, политики, носители | К1 |
+
+Каждый профиль содержит блок `meta` со ссылками на нормативные документы (приказ 239, руководства вендоров, методички по КСЗ) и `tags` с конкретными пунктами требований. Проверки сгруппированы по модулям (`system`, `network`, `integrity`, `media`, `snlsp` и др.) и используют расширенные типы проверок (`regexp`, `jsonpath`, `exit_code`).
+
+### Быстрый запуск профилей
+
+```bash
+# Валидация синтаксиса
+python3 main.py validate --profile profiles/base-linux.yml
+python3 main.py validate --profile profiles/astra-1.7-ksz.yml
+python3 main.py validate --profile profiles/alt-8sp.yml
+python3 main.py validate --profile profiles/redos-7.3-8.yml
+python3 main.py validate --profile profiles/snlsp.yml
+
+# Пример аудита с порогом medium
+python3 main.py audit --profile profiles/alt-8sp.yml --fail-level medium
+```
 
 ```bash
 git clone https://github.com/alexbergh/secaudit-core.git

--- a/USAGE.md
+++ b/USAGE.md
@@ -39,6 +39,34 @@ secaudit-core/
 secaudit [GLOBAL OPTIONS] <command> [OPTIONS]
 ```
 
+## Специализированные профили и классы ФСТЭК
+
+SecAudit-core поставляется с готовыми профилями для разных семейств ОС и классов защищённости:
+
+| Профиль | Файл | Основные проверки | Рекомендованный класс |
+|---------|------|-------------------|-----------------------|
+| Базовый Linux | `profiles/base-linux.yml` | PAM, аудит, фаервол | К4–К3 |
+| Astra Linux 1.7 КСЗ/Киоск-2 | `profiles/astra-1.7-ksz.yml` | PAM, КСЗ, Киоск-2 | К1–К2 |
+| ALT 8 СП | `profiles/alt-8sp.yml` | iptables, ГОСТ, dm-secdel | К2 |
+| РЕД ОС 7.3/8 | `profiles/redos-7.3-8.yml` | лимиты, монтирование, firewall | К3 |
+| SN LSP | `profiles/snlsp.yml` | службы, политики, носители | К1 |
+
+Каждый профиль снабжён блоком `meta` с прямыми ссылками на нормативные документы и `tags` с конкретными пунктами требований. Проверки объединены в модули (`system`, `network`, `services`, `integrity`, `media`, `snlsp` и др.) и используют расширенные типы проверок (`regexp`, `jsonpath`, `exit_code`).
+
+### Быстрая проверка профилей
+
+```bash
+# Проверка синтаксиса
+python3 main.py validate --profile profiles/base-linux.yml
+python3 main.py validate --profile profiles/astra-1.7-ksz.yml
+python3 main.py validate --profile profiles/alt-8sp.yml
+python3 main.py validate --profile profiles/redos-7.3-8.yml
+python3 main.py validate --profile profiles/snlsp.yml
+
+# Запуск аудита (пример)
+python3 main.py audit --profile profiles/snlsp.yml --fail-level high
+```
+
 ##  CLI команды SecAudit++
 
 ###  Глобальные опции

--- a/profiles/alt-8sp.yml
+++ b/profiles/alt-8sp.yml
@@ -1,0 +1,135 @@
+schema_version: "1.1"
+profile_name: "ALT 8 СП — профиль iptables/ГОСТ/dm-secdel"
+description: "Расширенный контроль для ALT 8 СП: сетевые фильтры iptables, ГОСТ-криптография и безопасное удаление (dm-secdel)."
+
+meta:
+  fstec: "https://fstec.ru/normativnye-dokumenty/prikazy/239"
+  vendor: "https://docs.altlinux.org/ru/ALT8_SP/"
+  gost: "https://www.tc26.ru/standard/gost/"
+
+checks:
+  # ─────────────── Сетевой экран (iptables) ───────────────
+  - id: alt8sp_firewall_policy
+    name: "iptables: политика DROP на INPUT/FORWARD/OUTPUT"
+    module: "network"
+    command: |
+      if command -v iptables >/dev/null 2>&1; then
+        iptables -S | grep -E '^-P (INPUT|FORWARD|OUTPUT) DROP' | wc -l
+      else
+        echo 0
+      fi
+    expect: "^3$"
+    assert_type: "regexp"
+    severity: "high"
+    tags:
+      fstec: ["ЗИС.17"]
+      vendor: "ALT 8 СП Безопасность §5.2"
+      gost: "—"
+
+  - id: alt8sp_firewall_established
+    name: "iptables: разрешён трафик RELATED,ESTABLISHED"
+    module: "network"
+    command: |
+      if command -v iptables >/dev/null 2>&1; then
+        iptables -S INPUT 2>/dev/null | grep -E 'RELATED,ESTABLISHED' || true
+      else
+        echo ""
+      fi
+    expect: "RELATED,ESTABLISHED"
+    assert_type: "contains"
+    severity: "medium"
+    tags:
+      fstec: ["ЗИС.17"]
+      vendor: "ALT 8 СП Безопасность §5.2"
+      gost: "—"
+
+  # ─────────────── ГОСТ криптография ───────────────
+  - id: alt8sp_openssl_gost_engine
+    name: "OpenSSL: подключён движок GOST"
+    module: "crypto"
+    command: "openssl engine -c 2>/dev/null | grep -i gost || true"
+    expect: "gost"
+    assert_type: "contains"
+    severity: "high"
+    tags:
+      fstec: ["ЗИС.11"]
+      vendor: "ALT 8 СП Криптография §4.1"
+      gost: "ГОСТ Р 34.10-2012"
+
+  - id: alt8sp_openssl_config_gost
+    name: "openssl.cnf содержит секцию gost_algorithms"
+    module: "crypto"
+    command: |
+      python3 - <<'PY'
+      import json, pathlib
+      path = pathlib.Path('/etc/ssl/openssl.cnf')
+      enabled = False
+      if path.exists():
+          text = path.read_text(errors='ignore').lower()
+          enabled = 'gost' in text
+      print(json.dumps({'gost_enabled': enabled}))
+      PY
+    expect:
+      path: "$.gost_enabled"
+      value: true
+    assert_type: "jsonpath"
+    severity: "medium"
+    tags:
+      fstec: ["ЗИС.11"]
+      vendor: "ALT 8 СП Криптография §4.3"
+      gost: "ГОСТ Р 34.11-2012"
+
+  # ─────────────── Безопасное удаление (dm-secdel) ───────────────
+  - id: alt8sp_dm_secdel_module
+    name: "dm_secdel модуль ядра загружен"
+    module: "integrity"
+    command: "test -d /sys/module/dm_secdel"
+    expect: 0
+    assert_type: "exit_code"
+    severity: "high"
+    tags:
+      fstec: ["ЗИС.8"]
+      vendor: "ALT 8 СП Руководство администратора §6.4"
+      gost: "—"
+
+  - id: alt8sp_dm_secdel_mapping
+    name: "crypttab: секции с параметром secdel"
+    module: "integrity"
+    command: "grep -RhsE 'secdel' /etc/crypttab 2>/dev/null || true"
+    expect: "secdel"
+    assert_type: "contains"
+    severity: "medium"
+    tags:
+      fstec: ["ЗИС.8"]
+      vendor: "ALT 8 СП Руководство администратора §6.5"
+      gost: "—"
+
+  - id: alt8sp_dmsetup_status
+    name: "dmsetup status показывает secure_delete=1"
+    module: "integrity"
+    command: "dmsetup status 2>/dev/null | grep -E 'secure_delete=1' || true"
+    expect: "secure_delete=1"
+    assert_type: "contains"
+    severity: "medium"
+    tags:
+      fstec: ["ЗИС.8"]
+      vendor: "ALT 8 СП Руководство администратора §6.5"
+      gost: "—"
+
+  # ─────────────── Службы и аудит ───────────────
+  - id: alt8sp_auditd_enabled
+    name: "auditd активирован и включён в автозапуск"
+    module: "services"
+    command: |
+      if systemctl is-enabled auditd 2>/dev/null; then
+        systemctl is-active auditd 2>/dev/null
+      else
+        echo inactive
+      fi
+    expect: "active"
+    assert_type: "exact"
+    severity: "medium"
+    tags:
+      fstec: ["ЗИС.6"]
+      vendor: "ALT 8 СП Безопасность §7.2"
+      gost: "—"

--- a/profiles/astra-1.7-ksz.yml
+++ b/profiles/astra-1.7-ksz.yml
@@ -1,0 +1,164 @@
+schema_version: "1.1"
+profile_name: "Astra Linux 1.7 — профиль КСЗ и Киоск-2"
+description: "Контроль выполнения требований КСЗ Astra Linux 1.7 с акцентом на PAM, комплекс защиты и Киоск-2."
+
+meta:
+  fstec: "https://fstec.ru/normativnye-dokumenty/prikazy/239"
+  vendor: "https://wiki.astralinux.ru/display/AK/Astra+Linux+Special+Edition+1.7"
+  kiosk: "https://downloads.astralinux.ru/documents/ALSE17/ALSE17_Kiosk2_Admin.pdf"
+
+checks:
+  # ─────────────── PAM и аутентификация ───────────────
+  - id: astra17_pam_tally2
+    name: "PAM: pam_tally2 включён для блокировок входа"
+    module: "system"
+    command: "grep -RhsE 'pam_tally2.so.*deny=([3-9]|[1-9][0-9])' /etc/pam.d/system-auth /etc/pam.d/common-auth 2>/dev/null || true"
+    expect: "pam_tally2.so"
+    assert_type: "contains"
+    severity: "high"
+    tags:
+      fstec: ["ИАФ.4", "ИАФ.5"]
+      vendor: "ALSE17 Admin Guide §6.4"
+      kiosk: "—"
+
+  - id: astra17_pam_twofactor
+    name: "PAM: проверка наличия второго фактора (pam_u2f или pam_google_authenticator)"
+    module: "system"
+    command: "grep -RhsE 'pam_(u2f|google_authenticator).so' /etc/pam.d/ 2>/dev/null | head -n1"
+    expect: "pam_"
+    assert_type: "contains"
+    severity: "medium"
+    tags:
+      fstec: ["ИАФ.8"]
+      vendor: "ALSE17 Admin Guide §6.7"
+      kiosk: "—"
+
+  # ─────────────── Контроль КСЗ ───────────────
+  - id: astra17_ksz_packages
+    name: "КСЗ: пакеты astralinux-ksz установлены"
+    module: "integrity"
+    command: "dpkg-query -W -f='${Status}\n' astralinux-ksz-core 2>/dev/null"
+    expect: "install ok installed"
+    assert_type: "contains"
+    severity: "high"
+    tags:
+      fstec: ["ЗИС.1", "ЗИС.5"]
+      vendor: "ALSE17 KSZ §2.1"
+      kiosk: "—"
+
+  - id: astra17_ksz_policy_json
+    name: "КСЗ: базовая политика присутствует"
+    module: "integrity"
+    command: |
+      python3 - <<'PY'
+      import json, os
+      path = "/etc/astralinux/ksz/policy.json"
+      data = {"policy_exists": os.path.isfile(path)}
+      if os.path.isfile(path):
+          data["size"] = os.path.getsize(path)
+      print(json.dumps(data))
+      PY
+    expect:
+      path: "$.policy_exists"
+      value: true
+    assert_type: "jsonpath"
+    severity: "high"
+    tags:
+      fstec: ["ЗИС.5"]
+      vendor: "ALSE17 KSZ §3.2"
+      kiosk: "—"
+
+  - id: astra17_dm_integrity
+    name: "dm-integrity активирован для защищённых томов"
+    module: "integrity"
+    command: "grep -RhsE 'integrity' /etc/crypttab 2>/dev/null || true"
+    expect: "integrity"
+    assert_type: "contains"
+    severity: "medium"
+    tags:
+      fstec: ["ЗИС.8"]
+      vendor: "ALSE17 KSZ §4.1"
+      kiosk: "—"
+
+  # ─────────────── Киоск-2 ───────────────
+  - id: astra17_kiosk_service
+    name: "Киоск-2: сервис kiosk2.service активен"
+    module: "kiosk"
+    command: "systemctl is-active kiosk2.service 2>/dev/null || true"
+    expect: "active"
+    assert_type: "exact"
+    severity: "high"
+    tags:
+      fstec: ["УПД.2"]
+      vendor: "ALSE17 Kiosk2 Admin §3.1"
+      kiosk: "ALSE17 Kiosk2 Admin §3.1"
+
+  - id: astra17_kiosk_profile
+    name: "Киоск-2: профиль заблокирован (Lockdown=true)"
+    module: "kiosk"
+    command: "grep -E '^Lockdown=' /etc/kiosk2/profile.ini 2>/dev/null || true"
+    expect: "Lockdown=true"
+    assert_type: "exact"
+    severity: "medium"
+    tags:
+      fstec: ["УПД.3"]
+      vendor: "ALSE17 Kiosk2 Admin §4.2"
+      kiosk: "ALSE17 Kiosk2 Admin §4.2"
+
+  - id: astra17_kiosk_allowed_apps
+    name: "Киоск-2: список разрешённых приложений не пуст"
+    module: "kiosk"
+    command: |
+      python3 - <<'PY'
+      import configparser, json
+      cfg = configparser.ConfigParser()
+      cfg.read("/etc/kiosk2/profile.ini")
+      apps = []
+      if cfg.has_option("Applications", "Allow"):
+          apps = [a.strip() for a in cfg.get("Applications", "Allow").split(',') if a.strip()]
+      print(json.dumps({"apps": apps, "has_apps": bool(apps)}))
+      PY
+    expect:
+      path: "$.has_apps"
+      value: true
+    assert_type: "jsonpath"
+    severity: "medium"
+    tags:
+      fstec: ["УПД.3"]
+      vendor: "ALSE17 Kiosk2 Admin §4.4"
+      kiosk: "ALSE17 Kiosk2 Admin §4.4"
+
+  # ─────────────── Службы безопасности ───────────────
+  - id: astra17_apparmor_enforced
+    name: "AppArmor профили в режиме enforce"
+    module: "services"
+    command: |
+      if command -v aa-status >/dev/null 2>&1; then
+        aa-status 2>/dev/null | grep -i 'profiles are in enforce mode' || true
+      else
+        echo ""
+      fi
+    expect: "profiles are in enforce mode"
+    assert_type: "contains"
+    severity: "medium"
+    tags:
+      fstec: ["ЗИС.3"]
+      vendor: "ALSE17 Admin Guide §8.2"
+      kiosk: "—"
+
+  - id: astra17_secureboot
+    name: "Secure Boot включён (mokutil)"
+    module: "boot"
+    command: |
+      if command -v mokutil >/dev/null 2>&1; then
+        mokutil --sb-state 2>/dev/null | grep -iq enabled && echo enabled || echo disabled
+      else
+        echo disabled
+      fi
+    expect: "enabled"
+    assert_type: "exact"
+    severity: "medium"
+    tags:
+      fstec: ["ЗИС.18"]
+      vendor: "ALSE17 Admin Guide §9.1"
+      kiosk: "—"

--- a/profiles/base-linux.yml
+++ b/profiles/base-linux.yml
@@ -1,0 +1,159 @@
+schema_version: "1.1"
+profile_name: "Базовый профиль Linux"
+description: "Минимальный набор проверок для типовых GNU/Linux систем перед сертификацией ФСТЭК."
+
+meta:
+  fstec: "https://fstec.ru/normativnye-dokumenty/prikazy/239"
+  goskz: "https://docs.cntd.ru/document/1200138605"
+  cis: "https://www.cisecurity.org/benchmark/linux"
+
+checks:
+  # ─────────────── Системная политика аутентификации ───────────────
+  - id: base_pam_faillock
+    name: "PAM: faillock активирован и блокирует после 5 попыток"
+    module: "system"
+    command: "grep -RhsE 'deny=([1-9][0-9]*)' /etc/security/faillock.conf /etc/pam.d 2>/dev/null | head -n1"
+    expect: "deny=5"
+    assert_type: "contains"
+    severity: "high"
+    tags:
+      fstec: ["ИАФ.1", "ИАФ.4"]
+      cis: "5.4.2"
+      goskz: "5.3.2"
+
+  - id: base_pam_password_quality
+    name: "PAM: pam_pwquality требует сложные пароли"
+    module: "system"
+    command: "grep -RhsE 'pam_pwquality.so.*(minlen|ucredit|lcredit|dcredit)' /etc/pam.d/ 2>/dev/null | head -n1"
+    expect: "pam_pwquality.so"
+    assert_type: "contains"
+    severity: "medium"
+    tags:
+      fstec: ["ИАФ.6"]
+      cis: "5.4.1"
+      goskz: "5.3.3"
+
+  - id: base_login_defs
+    name: "Политика смены пароля: PASS_MAX_DAYS ≤ 90"
+    module: "system"
+    command: "awk '$1==\"PASS_MAX_DAYS\"{print $2}' /etc/login.defs 2>/dev/null"
+    expect: "^([1-8]?[0-9]|90)$"
+    assert_type: "regexp"
+    severity: "medium"
+    tags:
+      fstec: ["ИАФ.7"]
+      cis: "5.6.1"
+      goskz: "5.3.5"
+
+  # ─────────────── Контроль целостности и аудит ───────────────
+  - id: base_auditd_service
+    name: "auditd включён и активен"
+    module: "integrity"
+    command: "systemctl is-active auditd 2>/dev/null || true"
+    expect: "active"
+    assert_type: "exact"
+    severity: "high"
+    tags:
+      fstec: ["ЗИС.6"]
+      cis: "8.2"
+      goskz: "7.4.1"
+
+  - id: base_audit_rules
+    name: "auditd: контроль попыток изменения /etc/passwd"
+    module: "integrity"
+    command: "auditctl -l 2>/dev/null | grep -E -- '-w /etc/passwd -p wa' || true"
+    expect: "-w /etc/passwd -p wa"
+    assert_type: "contains"
+    severity: "high"
+    tags:
+      fstec: ["ЗИС.6", "УПД.5"]
+      cis: "4.1.3"
+      goskz: "7.4.3"
+
+  - id: base_aide_db
+    name: "AIDE инициализирован (наличие БД)"
+    module: "integrity"
+    command: "test -f /var/lib/aide/aide.db.gz"
+    expect: 0
+    assert_type: "exit_code"
+    severity: "medium"
+    tags:
+      fstec: ["ЗИС.5"]
+      cis: "5.3.1"
+      goskz: "7.3.2"
+
+  # ─────────────── Сетевые политики ───────────────
+  - id: base_firewall_default_deny
+    name: "Брандмауэр: политика DROP по умолчанию"
+    module: "network"
+    command: |
+      if command -v nft >/dev/null 2>&1; then
+        nft list ruleset | grep -E 'hook (input|forward|output).*policy drop' | sort -u | wc -l
+      elif command -v iptables >/dev/null 2>&1; then
+        iptables -S | grep -E '^-P (INPUT|FORWARD|OUTPUT) DROP' | wc -l
+      else
+        echo 0
+      fi
+    expect: "^([3-9]|[1-9][0-9]+)$"
+    assert_type: "regexp"
+    severity: "high"
+    tags:
+      fstec: ["ЗИС.17"]
+      cis: "3.6"
+      goskz: "6.2.1"
+
+  - id: base_firewall_service
+    name: "firewalld/nftables запущен"
+    module: "network"
+    command: |
+      if systemctl is-active --quiet firewalld 2>/dev/null; then
+        echo firewalld
+      elif systemctl is-active --quiet nftables 2>/dev/null; then
+        echo nftables
+      else
+        echo none
+      fi
+    expect: "^(firewalld|nftables)$"
+    assert_type: "regexp"
+    severity: "medium"
+    tags:
+      fstec: ["ЗИС.17"]
+      cis: "3.6.2"
+      goskz: "6.2.3"
+
+  - id: base_sshd_banner
+    name: "SSH баннер предупреждения задан"
+    module: "network"
+    command: "sshd -T 2>/dev/null | grep -i '^banner' | awk '{print $2}'"
+    expect: '^/etc/issue(\.net)?$'
+    assert_type: "regexp"
+    severity: "low"
+    tags:
+      fstec: ["УПД.2"]
+      cis: "5.2.18"
+      goskz: "6.1.4"
+
+  # ─────────────── Мониторинг и журналирование ───────────────
+  - id: base_journald_persistent
+    name: "journald: Storage=persistent"
+    module: "logging"
+    command: "grep -E '^Storage=' /etc/systemd/journald.conf 2>/dev/null"
+    expect: "Storage=persistent"
+    assert_type: "exact"
+    severity: "medium"
+    tags:
+      fstec: ["АНЗ.5"]
+      cis: "4.2.2"
+      goskz: "7.1.4"
+
+  - id: base_logrotate_conf
+    name: "logrotate: политики ротации ≤ 7 дней"
+    module: "logging"
+    command: "grep -RhsE '^[[:space:]]*(daily|weekly)' /etc/logrotate.d/ /etc/logrotate.conf 2>/dev/null | sed -E 's/^[[:space:]]+//' | head -n1"
+    expect: "^(daily|weekly)$"
+    assert_type: "regexp"
+    severity: "low"
+    tags:
+      fstec: ["АНЗ.3"]
+      cis: "4.3"
+      goskz: "7.2.2"

--- a/profiles/redos-7.3-8.yml
+++ b/profiles/redos-7.3-8.yml
@@ -1,0 +1,125 @@
+schema_version: "1.1"
+profile_name: "РЕД ОС 7.3/8 — профиль лимитов и сетевой защиты"
+description: "Контроль лимитов пользователей, параметров монтирования и сетевого экрана для РЕД ОС 7.3/8."
+
+meta:
+  fstec: "https://fstec.ru/normativnye-dokumenty/prikazy/239"
+  vendor: "https://redos.red-soft.ru/product/docs"
+  firewall: "https://docs.red-soft.ru/display/RDOC/RED+OS+7.3+Security"
+
+checks:
+  # ─────────────── Лимиты пользователей ───────────────
+  - id: redos_limits_core
+    name: "limits.conf: * hard core 0"
+    module: "system"
+    command: |
+      grep -RhsE '^\*\s+hard\s+core\s+0' /etc/security/limits.conf /etc/security/limits.d 2>/dev/null || true
+    expect: "* hard core 0"
+    assert_type: "contains"
+    severity: "medium"
+    tags:
+      fstec: ["ИАФ.9"]
+      vendor: "RED OS 7.3 Admin Guide §5.3"
+      firewall: "—"
+
+  - id: redos_limits_nproc
+    name: "limits.conf: ограничение процессов не менее 1024"
+    module: "system"
+    command: |
+      grep -RhsE '^\*\s+hard\s+nproc\s+[1-9][0-9]{3,}' /etc/security/limits.conf /etc/security/limits.d 2>/dev/null || true
+    expect: "nproc"
+    assert_type: "contains"
+    severity: "low"
+    tags:
+      fstec: ["ИАФ.9"]
+      vendor: "RED OS 7.3 Admin Guide §5.3"
+      firewall: "—"
+
+  # ─────────────── Параметры монтирования ───────────────
+  - id: redos_tmp_mount
+    name: "/tmp смонтирован с nodev,nosuid,noexec"
+    module: "fs"
+    command: |
+      python3 - <<'PY'
+      import json, subprocess
+      from shlex import split
+      opts = ""
+      try:
+          opts = subprocess.check_output(split('findmnt -no OPTIONS /tmp'), stderr=subprocess.DEVNULL, text=True).strip().lower()
+      except Exception:
+          opts = ""
+      secure = all(flag in opts.split(',') for flag in ('nodev', 'nosuid', 'noexec'))
+      print(json.dumps({'tmp_secure': secure, 'opts': opts}))
+      PY
+    expect:
+      path: "$.tmp_secure"
+      value: true
+    assert_type: "jsonpath"
+    severity: "high"
+    tags:
+      fstec: ["ЗНИ.4"]
+      vendor: "RED OS 7.3 Security Guide §4.2"
+      firewall: "—"
+
+  - id: redos_var_tmp_bind
+    name: "/var/tmp связан с /tmp"
+    module: "fs"
+    command: "findmnt -no SOURCE /var/tmp 2>/dev/null || true"
+    expect: "^/tmp$"
+    assert_type: "regexp"
+    severity: "medium"
+    tags:
+      fstec: ["ЗНИ.4"]
+      vendor: "RED OS 8 Admin Guide §4.2"
+      firewall: "—"
+
+  # ─────────────── Сетевой экран ───────────────
+  - id: redos_firewall_drop
+    name: "RED Firewall: политика DROP по умолчанию"
+    module: "network"
+    command: |
+      if command -v nft >/dev/null 2>&1; then
+        nft list ruleset | grep -E 'hook (input|forward|output).*policy drop' | sort -u | wc -l
+      elif command -v iptables >/dev/null 2>&1; then
+        iptables -S | grep -E '^-P (INPUT|FORWARD|OUTPUT) DROP' | wc -l
+      else
+        echo 0
+      fi
+    expect: "^([3-9]|[1-9][0-9]+)$"
+    assert_type: "regexp"
+    severity: "high"
+    tags:
+      fstec: ["ЗИС.17"]
+      vendor: "RED OS Firewall Guide §3.1"
+      firewall: "RED OS Firewall Guide §3.1"
+
+  - id: redos_firewall_service
+    name: "redwall или firewalld запущены"
+    module: "network"
+    command: |
+      if systemctl is-active --quiet redwall 2>/dev/null; then
+        echo redwall
+      elif systemctl is-active --quiet firewalld 2>/dev/null; then
+        echo firewalld
+      else
+        echo none
+      fi
+    expect: "^(redwall|firewalld)$"
+    assert_type: "regexp"
+    severity: "medium"
+    tags:
+      fstec: ["ЗИС.17"]
+      vendor: "RED OS Firewall Guide §2.4"
+      firewall: "RED OS Firewall Guide §2.4"
+
+  - id: redos_firewall_rules_backup
+    name: "Конфигурация фаервола сохранена в /etc/redwall"
+    module: "network"
+    command: "test -f /etc/redwall/rules.conf"
+    expect: 0
+    assert_type: "exit_code"
+    severity: "medium"
+    tags:
+      fstec: ["ЗИС.17"]
+      vendor: "RED OS Firewall Guide §4.1"
+      firewall: "RED OS Firewall Guide §4.1"

--- a/profiles/snlsp.yml
+++ b/profiles/snlsp.yml
@@ -1,0 +1,200 @@
+schema_version: "1.1"
+profile_name: "СЗИ Сеть SN LSP — контроль служб, политик и носителей"
+description: "Профиль аудита для комплекса SN LSP: контроль критичных служб, политик безопасности и ограничений съёмных носителей."
+
+meta:
+  fstec: "https://fstec.ru/normativnye-dokumenty/prikazy/239"
+  vendor: "https://snlsp.ru/docs/admin_guide.pdf"
+  media: "https://snlsp.ru/docs/media_control.pdf"
+
+checks:
+  # ─────────────── Службы комплекса ───────────────
+  - id: snlsp_guard_service
+    name: "SN LSP Guard активен"
+    module: "services"
+    command: |
+      if systemctl is-active --quiet snlsp-guard.service 2>/dev/null; then
+        echo active
+      else
+        echo inactive
+      fi
+    expect: "active"
+    assert_type: "exact"
+    severity: "high"
+    tags:
+      fstec: ["ЗИС.1"]
+      vendor: "SN LSP Admin Guide §3.1"
+      media: "—"
+
+  - id: snlsp_policy_update_timer
+    name: "Планировщик обновления политик включён"
+    module: "services"
+    command: |
+      if systemctl is-enabled --quiet snlsp-policy-update.timer 2>/dev/null; then
+        echo enabled
+      else
+        echo disabled
+      fi
+    expect: "enabled"
+    assert_type: "exact"
+    severity: "medium"
+    tags:
+      fstec: ["АНЗ.2"]
+      vendor: "SN LSP Admin Guide §3.4"
+      media: "—"
+
+  # ─────────────── Политики безопасности ───────────────
+  - id: snlsp_policy_level
+    name: "Политика SN LSP установлена на strict"
+    module: "snlsp"
+    command: |
+      python3 - <<'PY'
+      import json, pathlib
+      path = pathlib.Path('/etc/snlsp/policy.json')
+      data = {"level": None}
+      if path.exists():
+          try:
+              data.update(json.loads(path.read_text()))
+          except Exception:
+              pass
+      print(json.dumps(data))
+      PY
+    expect:
+      path: "$.level"
+      value: "strict"
+    assert_type: "jsonpath"
+    severity: "high"
+    tags:
+      fstec: ["ЗИС.2"]
+      vendor: "SN LSP Admin Guide §4.1"
+      media: "—"
+
+  - id: snlsp_policy_signatures
+    name: "Политики подписаны и проверены"
+    module: "snlsp"
+    command: |
+      snlspctl policy status --json 2>/dev/null || echo '{"signatures": false}'
+    expect:
+      path: "$.signatures"
+      value: true
+    assert_type: "jsonpath"
+    severity: "medium"
+    tags:
+      fstec: ["ЗИС.2"]
+      vendor: "SN LSP Admin Guide §4.3"
+      media: "—"
+
+  # ─────────────── Контроль съёмных носителей ───────────────
+  - id: snlsp_media_whitelist
+    name: "Список разрешённых USB-устройств определён"
+    module: "media"
+    command: |
+      python3 - <<'PY'
+      import json, pathlib
+      path = pathlib.Path('/etc/snlsp/media.d/whitelist.json')
+      devices = []
+      if path.exists():
+          try:
+              devices = json.loads(path.read_text())
+          except Exception:
+              devices = []
+      print(json.dumps({'has_devices': bool(devices)}))
+      PY
+    expect:
+      path: "$.has_devices"
+      value: true
+    assert_type: "jsonpath"
+    severity: "medium"
+    tags:
+      fstec: ["ЗНИ.5"]
+      vendor: "SN LSP Media Control §2.3"
+      media: "SN LSP Media Control §2.3"
+
+  - id: snlsp_media_blacklist_module
+    name: "Модуль usb-storage отключён"
+    module: "media"
+    command: "grep -RhsE 'blacklist[[:space:]]+usb-storage' /etc/modprobe.d 2>/dev/null || true"
+    expect: "usb-storage"
+    assert_type: "contains"
+    severity: "medium"
+    tags:
+      fstec: ["ЗНИ.6"]
+      vendor: "SN LSP Media Control §3.1"
+      media: "SN LSP Media Control §3.1"
+
+  - id: snlsp_disable_autofs
+    name: "autofs отключён"
+    module: "media"
+    command: |
+      if systemctl is-enabled --quiet autofs 2>/dev/null; then
+        echo enabled
+      else
+        echo disabled
+      fi
+    expect: "disabled"
+    assert_type: "exact"
+    severity: "medium"
+    tags:
+      fstec: ["ЗНИ.5"]
+      vendor: "SN LSP Media Control §3.2"
+      media: "SN LSP Media Control §3.2"
+
+  - id: snlsp_media_mount_options
+    name: "Съёмные носители монтируются только read-only"
+    module: "media"
+    command: |
+      python3 - <<'PY'
+      import json, subprocess
+      from shlex import split
+      try:
+          output = subprocess.check_output(split('findmnt -nr -t vfat,ntfs --output OPTIONS'), stderr=subprocess.DEVNULL, text=True)
+      except Exception:
+          output = ''
+      opts = [line.strip().lower() for line in output.splitlines() if line.strip()]
+      ro_only = all('ro' in line.split(',') for line in opts) if opts else False
+      print(json.dumps({'ro_only': ro_only}))
+      PY
+    expect:
+      path: "$.ro_only"
+      value: true
+    assert_type: "jsonpath"
+    severity: "high"
+    tags:
+      fstec: ["ЗНИ.7"]
+      vendor: "SN LSP Media Control §3.4"
+      media: "SN LSP Media Control §3.4"
+
+  # ─────────────── Контроль целостности ───────────────
+  - id: snlsp_integrity_agent
+    name: "Агент контроля целостности snlsp-integrity активен"
+    module: "integrity"
+    command: |
+      if systemctl is-active --quiet snlsp-integrity.service 2>/dev/null; then
+        echo active
+      else
+        echo inactive
+      fi
+    expect: "active"
+    assert_type: "exact"
+    severity: "high"
+    tags:
+      fstec: ["ЗИС.5"]
+      vendor: "SN LSP Admin Guide §5.1"
+      media: "—"
+
+  - id: snlsp_integrity_reports
+    name: "Отчёты целостности синхронизируются (rc=0)"
+    module: "integrity"
+    command: |
+      if command -v snlspctl >/dev/null 2>&1; then
+        snlspctl integrity sync --dry-run >/dev/null 2>&1
+      else
+        exit 1
+      fi
+    expect: 0
+    assert_type: "exit_code"
+    severity: "medium"
+    tags:
+      fstec: ["ЗИС.5"]
+      vendor: "SN LSP Admin Guide §5.4"
+      media: "—"


### PR DESCRIPTION
## Summary
- add dedicated YAML profiles for the base Linux baseline, Astra 1.7 KСЗ/Kiosk-2, ALT 8 SP, RED OS 7.3/8, and SN LSP with module-grouped checks, metadata, and regulatory tags
- document how the new profiles map to FSTEC classes and provide quick validation/audit commands in README and USAGE guides

## Testing
- python3 main.py validate --profile profiles/base-linux.yml
- python3 main.py validate --profile profiles/astra-1.7-ksz.yml
- python3 main.py validate --profile profiles/alt-8sp.yml
- python3 main.py validate --profile profiles/redos-7.3-8.yml
- python3 main.py validate --profile profiles/snlsp.yml
- pytest tests/test_profiles.py