### PR TITLE
Add host metadata to report filenames and IP list

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -138,7 +138,7 @@ secaudit --profile profiles/alt.yml audit --fail-level medium
 - `results/report.json` — полный список проверок.
 - `results/report_grouped.json` — сгруппированные результаты.
 - `results/report.md` — Markdown-отчёт.
-- `results/report.html` — HTML-отчёт с аккордеонами по модулям.
+- `results/report_<hostname>_<datetime>.html` — HTML-отчёт с аккордеонами по модулям (имя хоста и дата в названии).
 
 ##  Пример YAML-профиля
 ```yaml


### PR DESCRIPTION
## Summary
- expose host metadata collection so the CLI can reuse it
- enrich host IP detection to include all available addresses and reuse metadata when rendering reports
- include the hostname and timestamp in generated HTML report filenames and document the new location

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfd0e3041483259a699af68cdedf8f