### PR TITLE
Fix malformed profile entries

### DIFF
--- a/profiles/base-linux.yml
+++ b/profiles/base-linux.yml
@@ -292,12 +292,9 @@ checks:
     module: "integrity"
     command: |
       auditctl -l 2>/dev/null \
-        | grep -E -- '(-w /boot/(grub2/)?grub.cfg -p wa -k (boot|grub)|-w /boot/(grub2/)?grubenv -p wa -k (boot|grub)|-w /efi -p wa -k efi)' || true
-    expect: '(?s)(?=.*grub.cfg)(?=.*grubenv)'
+        | grep -E -- '(-w /boot/(grub2/)?grub.cfg -p wa -k (boot|grub)|-w /boot/(grub2/)?grubenv -p wa -k (boot|grub)|-w /(boot|efi) -p wa -k (boot|efi))' || true
+    expect: '(?s)(?=.*grub.cfg)(?=.*grubenv)(?=.*-w /(boot|efi) -p wa -k (boot|efi))'
     assert_type: "regexp"
-      auditctl -l 2>/dev/null | grep -E -- '-w /(boot|efi) -p wa -k (boot|efi)' || true
-    expect: "-w /boot"
-    assert_type: "contains"
     severity: "high"
     tags:
       fstec: ["ЗИС.6"]
@@ -312,9 +309,6 @@ checks:
         | grep -E -- '(-w /usr/bin/sudo -p xwa -k (privileged|sudo)|-w /bin/su -p xwa -k (privileged|su)|-w /usr/bin/passwd -p xwa -k (privileged|passwd))' || true
     expect: '(?s)(?=.*sudo)(?=.*su)(?=.*passwd)'
     assert_type: "regexp"
-      auditctl -l 2>/dev/null | grep -E -- '-w /(usr/bin/sudo|bin/su|usr/bin/passwd) -p xwa' || true
-    expect: "/usr/bin/sudo"
-    assert_type: "contains"
     severity: "high"
     tags:
       fstec: ["ЗИС.6"]
@@ -1099,12 +1093,6 @@ checks:
     module: "network"
     command: |
       for svc in cups.service avahi-daemon.service bluetooth.service ssh-agent.socket; do
-
-- id: base_services_redundant_disabled
-    name: "Лишние службы (CUPS/Avahi) отключены"
-    module: "network"
-    command: |
-      for svc in cups.service avahi-daemon.service bluetooth.service; do
         if systemctl list-unit-files "$svc" >/dev/null 2>&1; then
           state=$(systemctl is-enabled "$svc" 2>/dev/null || echo unknown)
           if ! echo "$state" | grep -Eq '^(disabled|masked)$'; then


### PR DESCRIPTION
## Summary
- fix malformed auditd profile entries that caused YAML parsing errors
- consolidate redundant services check to include ssh-agent and ensure proper YAML structure

## Testing
- pytest
