### PR TITLE
Adjust CLI info output text

### DIFF
--- a/modules/cli.py
+++ b/modules/cli.py
@@ -228,13 +228,20 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "-i",
+        "--info",
+        action="store_true",
+        help="Показать сведения о проекте и завершиться.",
+    )
+
+    parser.add_argument(
         "--profile",
         dest="profile",
         default=argparse.SUPPRESS,
         help=f"Путь к YAML-профилю (по умолчанию: {default_profile})",
     )
 
-    subs = parser.add_subparsers(dest="command", required=True, help="Доступные команды")
+    subs = parser.add_subparsers(dest="command", required=False, help="Доступные команды")
 
     sub_modules = subs.add_parser("list-modules", help="Показать все модули в профиле")
     _add_profile_arguments(sub_modules, default_profile=default_profile)
@@ -310,6 +317,15 @@ def parse_args() -> argparse.Namespace:
         args.profile = default_profile
     if hasattr(args, "profile_path"):
         delattr(args, "profile_path")
+
+    if getattr(args, "info", False):
+        if getattr(args, "command", None):
+            parser.error("--info нельзя использовать вместе с командами")
+        return args
+
+    if getattr(args, "command", None) is None:
+        parser.print_help()
+        sys.exit(1)
     if getattr(args, "command", None) == "audit":
         try:
             args.vars = parse_kv_pairs(getattr(args, "var", None), option="--var")

--- a/secaudit/main.py
+++ b/secaudit/main.py
@@ -95,8 +95,20 @@ def _apply_exit_policy(results: list[dict], fail_level: str, fail_on_undef: bool
     return exit_code
 
 
+def _print_project_info() -> None:
+    print("SecAudit++")
+    print("Alex Hellberg")
+    print("https://github.com/alexbergh/secaudit-core")
+    print("2025")
+    print("Проект распространяется под лицензией GPL-3.0")
+
+
 def main():
     args = parse_args()
+
+    if getattr(args, "info", False):
+        _print_project_info()
+        return
 
     # Определяем профиль
     profile_path = _resolve_profile_path(getattr(args, "profile", None))


### PR DESCRIPTION
## Summary
- update the CLI info output to remove the Russian labels before the project metadata
- adjust the license line to say the project is distributed under GPL-3.0

## Testing
- `python -m secaudit --info`