### PR TITLE
Handle --info without requiring a subcommand

### DIFF
--- a/secaudit/main.py
+++ b/secaudit/main.py
@@ -95,8 +95,20 @@ def _apply_exit_policy(results: list[dict], fail_level: str, fail_on_undef: bool
     return exit_code
 
 
+def _print_project_info() -> None:
+    print("SecAudit++")
+    print("Alex Hellberg")
+    print("https://github.com/alexbergh/secaudit-core")
+    print("2025")
+    print("Проект распространяется под лицензией GPL-3.0")
+
+
 def main():
     args = parse_args()
+
+    if getattr(args, "info", False):
+        _print_project_info()
+        return
 
     # Определяем профиль
     profile_path = _resolve_profile_path(getattr(args, "profile", None))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,3 +97,13 @@ def test_parse_args_defaults_to_baseline_profile(monkeypatch):
     args = cli.parse_args()
 
     assert args.profile == cli.DEFAULT_PROFILE_PATH
+
+
+def test_parse_args_info_flag_short_circuit(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["secaudit", "--info"])
+
+    args = cli.parse_args()
+
+    assert args.info is True
+    assert args.command is None
+    assert args.profile == cli.DEFAULT_PROFILE_PATH


### PR DESCRIPTION
## Summary
- short-circuit the CLI argument parser when only --info/-i is provided so argparse no longer complains about a missing subcommand
- add a regression test that ensures the info flag works without selecting a command

## Testing
- `pytest`
- `python -m secaudit --info`


------
https://chatgpt.com/codex/tasks/task_e_68e18bdb29fc8325aae1ae147bc0cfc3