### PR TITLE
Allow extends property in profile schema validation

### DIFF
--- a/seclib/validator.py
+++ b/seclib/validator.py
@@ -20,6 +20,16 @@ PROFILE_SCHEMA: Dict[str, Any] = {
         "schema_version": {"type": "string", "pattern": r"^1\.\d+$"},
         "profile_name": {"type": "string", "minLength": 1},
         "description": {"type": "string"},
+        "extends": {
+            "oneOf": [
+                {"type": "string", "minLength": 1},
+                {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {"type": "string", "minLength": 1},
+                },
+            ]
+        },
         "meta": {
             "type": "object",
             "additionalProperties": {"type": "string"},

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -94,6 +94,20 @@ def test_validate_profile_accepts_meta(minimal_check):
     assert is_valid, f"Profile unexpectedly invalid: {errors}"
 
 
+def test_validate_profile_accepts_extends(minimal_check):
+    profile = {
+        "schema_version": "1.1",
+        "profile_name": "Test",
+        "description": "Test profile",
+        "extends": ["../base/linux.yml", "../base/server.yml"],
+        "checks": [minimal_check],
+    }
+
+    is_valid, errors = validate_profile(profile)
+
+    assert is_valid, f"Profile unexpectedly invalid: {errors}"
+
+
 def test_validate_profile_rejects_object_expect_for_non_jsonpath(minimal_check):
     check = minimal_check.copy()
     check["expect"] = {"unsupported": True}


### PR DESCRIPTION
## Summary
- allow profiles to specify the `extends` key as a string or list when validating schema
- add a regression test that ensures profiles using `extends` remain valid

## Testing
- pytest tests/test_validator.py
- python3 main.py validate --profile profiles/base/server.yml
- python3 main.py audit --profile profiles/base/server.yml --level baseline