### PR TITLE
Adjust kernel baseline for RHEL/CentOS 7

### DIFF
--- a/profiles/base/linux.yml
+++ b/profiles/base/linux.yml
@@ -1172,14 +1172,69 @@ checks:
       goskz: "9.1.1"
 
   - id: base_kernel_min_version
-    name: "Ядро: версия не ниже 4.18"
+    name: "Ядро: версия не ниже 4.18 (3.10 для RHEL/CentOS 7)"
     module: "packages"
     command: |
+      default_min="4.18"
+      override_min="${SECAUDIT_KERNEL_MIN_VERSION:-}"
+      os_release_path="${SECAUDIT_KERNEL_OS_RELEASE:-/etc/os-release}"
+
+      detect_min_version() {
+        if [ -n "$override_min" ]; then
+          printf '%s\n' "$override_min"
+          return
+        fi
+
+        detected_min=""
+        os_release_id=""
+        os_release_version=""
+        os_release_like=""
+
+        if [ -r "$os_release_path" ]; then
+          # shellcheck disable=SC1090
+          . "$os_release_path"
+          os_release_id="${ID:-}"
+          os_release_version="${VERSION_ID:-}"
+          os_release_like="${ID_LIKE:-}"
+        fi
+
+        os_release_major="${os_release_version%%.*}"
+
+        case "$os_release_id" in
+          centos|rhel)
+            if [ "$os_release_major" = "7" ]; then
+              detected_min="3.10"
+            fi
+            ;;
+        esac
+
+        if [ -z "$detected_min" ] && [ -n "$os_release_like" ]; then
+          if printf '%s' "$os_release_like" | grep -Eq '(centos|rhel)'; then
+            if [ "$os_release_major" = "7" ]; then
+              detected_min="3.10"
+            fi
+          fi
+        fi
+
+        if [ -z "$detected_min" ] && command -v rpm >/dev/null 2>&1; then
+          rpm_rhel_macro=$(rpm --eval '%{?rhel}' 2>/dev/null | tr -d '[:space:]')
+          if [ "$rpm_rhel_macro" = "7" ]; then
+            detected_min="3.10"
+          fi
+        fi
+
+        if [ -n "$detected_min" ]; then
+          printf '%s\n' "$detected_min"
+        else
+          printf '%s\n' "$default_min"
+        fi
+      }
+
       current=$(uname -r 2>/dev/null | cut -d- -f1)
-      min="4.18"
       if [ -z "$current" ]; then
         echo unknown
       else
+        min=$(detect_min_version)
         first=$(printf '%s\n%s\n' "$min" "$current" | sort -V | head -n1)
         if [ "$first" = "$min" ]; then
           echo ok

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import re
+import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -38,6 +40,32 @@ def _get_check(profile: dict, check_id: str) -> dict:
         if check.get("id") == check_id:
             return check
     raise KeyError(f"check {check_id} not found")
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_check_command(check: dict, *, env: dict[str, str] | None = None) -> str:
+    command = check["command"]
+    run_env = os.environ.copy()
+    if env:
+        run_env.update(env)
+
+    result = subprocess.run(
+        command,
+        shell=True,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=run_env,
+    )
+    if result.returncode not in (0, 1):
+        raise RuntimeError(
+            f"command failed with rc={result.returncode}: {result.stderr.strip()}"
+        )
+    return result.stdout.strip()
 
 
 def test_base_ntp_sources_expectation_enforces_primary_and_total():
@@ -123,3 +151,94 @@ def test_debian_profile_overrides_shadow_permission_patterns():
     check_ids = _collect_check_ids(profile)
     assert "check_shadow_perms" in check_ids
     assert "check_gshadow_perms" in check_ids
+
+
+def test_base_kernel_min_version_allows_rhel7(tmp_path):
+    profile = _load_profile(BASE_PROFILE)
+    check = _get_check(profile, "base_kernel_min_version")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    _write_executable(
+        bin_dir / "uname",
+        "#!/bin/sh\n" "printf '3.10.0-1160.el7.x86_64\\n'\n",
+    )
+
+    _write_executable(
+        bin_dir / "rpm",
+        "#!/bin/sh\n"
+        "if [ \"$1\" = \"--eval\" ]; then\n"
+        "  printf '7\\n'\n"
+        "fi\n",
+    )
+
+    os_release = tmp_path / "os-release"
+    os_release.write_text(
+        "ID=centos\nVERSION_ID=7\nID_LIKE=\"rhel\"\n",
+        encoding="utf-8",
+    )
+
+    output = _run_check_command(
+        check,
+        env={
+            "SECAUDIT_KERNEL_OS_RELEASE": str(os_release),
+            "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+        },
+    )
+
+    assert output == "ok"
+
+
+def test_base_kernel_min_version_uses_default_for_debian(tmp_path):
+    profile = _load_profile(BASE_PROFILE)
+    check = _get_check(profile, "base_kernel_min_version")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "uname",
+        "#!/bin/sh\n" "printf '4.17.0-3-amd64\\n'\n",
+    )
+
+    os_release = tmp_path / "os-release"
+    os_release.write_text(
+        "ID=debian\nVERSION_ID=11\n",
+        encoding="utf-8",
+    )
+
+    output = _run_check_command(
+        check,
+        env={
+            "SECAUDIT_KERNEL_OS_RELEASE": str(os_release),
+            "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+        },
+    )
+
+    assert output == "4.17.0"
+
+
+def test_base_kernel_min_version_respects_override(tmp_path):
+    profile = _load_profile(BASE_PROFILE)
+    check = _get_check(profile, "base_kernel_min_version")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "uname",
+        "#!/bin/sh\n" "printf '4.19.0-21-amd64\\n'\n",
+    )
+
+    os_release = tmp_path / "os-release"
+    os_release.write_text("ID=debian\nVERSION_ID=11\n", encoding="utf-8")
+
+    output = _run_check_command(
+        check,
+        env={
+            "SECAUDIT_KERNEL_OS_RELEASE": str(os_release),
+            "SECAUDIT_KERNEL_MIN_VERSION": "5.0",
+            "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+        },
+    )
+
+    assert output == "4.19.0"


### PR DESCRIPTION
## Summary
- update the base kernel version rule to detect CentOS/RHEL 7 hosts via os-release data, rpm macros, and optional overrides
- keep the 4.18 baseline for other platforms while allowing a 3.10 minimum for the detected RHEL/CentOS 7 family
- add profile regression tests and helpers that simulate CentOS 7, Debian, and manual overrides for the kernel minimum check

## Testing
- pytest tests/test_profiles.py


------
https://chatgpt.com/codex/tasks/task_e_68e42a11e404832e9c6cbaaf3d606788